### PR TITLE
Add nullsafe access expression

### DIFF
--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -37,6 +37,10 @@
   name: (variable_name (name)) @property)
 (member_access_expression
   name: (name) @property)
+(nullsafe_member_access_expression
+  name: (variable_name (name)) @property)
+(nullsafe_member_access_expression
+  name: (name) @property)
 
 ; Variables
 


### PR DESCRIPTION
Adds nullsafe member access expression highlighting.

Before:
<img width="216" alt="Screenshot 2025-02-17 at 18 09 25" src="https://github.com/user-attachments/assets/cc81c754-b2d0-48ad-b762-11cfc187572d" />

After:
<img width="216" alt="Screenshot 2025-02-17 at 18 09 38" src="https://github.com/user-attachments/assets/8ef0d7a6-06e5-4c08-8857-693fe50dd2de" />
