### PR TITLE
Prevent PHPDoc from showing as distinct language

### DIFF
--- a/languages/phpdoc/config.toml
+++ b/languages/phpdoc/config.toml
@@ -7,3 +7,4 @@ brackets = [
   { start = "(", end = ")", close = true, newline = false },
   { start = "<", end = ">", close = true, newline = false },
 ]
+hidden = true


### PR DESCRIPTION
This PR marks PHPDoc as a language only used for injections, similar to [other languages for comment injections](https://github.com/zed-industries/zed/blob/482a45feacdddba417deaf92e9751aa2a4de5c66/crates/languages/src/jsdoc/config.toml#L8).

This fixes PHPDoc currently showing in the language selector:
<img width="562" alt="grafik" src="https://github.com/user-attachments/assets/16f614b2-b1db-4791-bba9-8dc7d04f0440" />
