### PR TITLE
Add yield and from syntax highlighting

### DIFF
--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -109,6 +109,7 @@
 "for" @keyword
 "foreach" @keyword
 "fn" @keyword
+"from" @keyword
 "function" @keyword
 "global" @keyword
 "goto" @keyword
@@ -139,3 +140,4 @@
 "use" @keyword
 "while" @keyword
 "xor" @keyword
+"yield" @keyword


### PR DESCRIPTION
Add syntax highlighting for generator `yield` and `yield from` ([docs](https://www.php.net/manual/en/language.generators.syntax.php#control-structures.yield.from)).

Before:
![Screenshot 2025-03-25 at 16 58 02](https://github.com/user-attachments/assets/8987bfd4-7a18-47b0-9da5-86a9f29522a3)

After:
![Screenshot 2025-03-25 at 16 57 50](https://github.com/user-attachments/assets/74be35f3-7f1f-4990-abaa-5e91caeab54f)
