### PR TITLE
Bump tree-sitter-phpdoc to v0.1.6

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/zed-extensions/php"
 [language_servers.intelephense]
 name = "Intelephense"
 language = "PHP"
-language_ids = { PHP = "php"}
+language_ids = { PHP = "php" }
 
 [language_servers.phpactor]
 name = "Phpactor"
@@ -22,4 +22,4 @@ path = "php"
 
 [grammars.phpdoc]
 repository = "https://github.com/claytonrcarter/tree-sitter-phpdoc"
-commit = "1d0e255b37477d0ca46f1c9e9268c8fa76c0b3fc"
+commit = "03bb10330704b0b371b044e937d5cc7cd40b4999"


### PR DESCRIPTION
Closes: https://github.com/zed-extensions/php/issues/16

| Before | After | 
| - | - |
| <img width="591" alt="Screenshot 2025-04-02 at 16 50 05" src="https://github.com/user-attachments/assets/e09f247a-2c25-4801-8d7a-23f68e4034c3" /> | <img width="580" alt="Screenshot 2025-04-02 at 16 49 47" src="https://github.com/user-attachments/assets/7c470931-c905-465b-af21-80aca28d88e8" /> |


- Diff: https://github.com/claytonrcarter/tree-sitter-phpdoc/compare/1d0e255b37477d0ca46f1c9e9268c8fa76c0b3fc...03bb10330704b0b371b044e937d5cc7cd40b4999