### PR TITLE
feat: support extending block comments

### DIFF
--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -3,6 +3,7 @@ grammar = "php"
 path_suffixes = ["php"]
 first_line_pattern = '^#!.*php'
 line_comments = ["// ", "# "]
+documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -11,6 +11,7 @@ brackets = [
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 collapsed_placeholder = "/* ... */"
 scope_opt_in_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
This does 2 things:
1. adds the needed config for this extension to support the [recently merged](https://github.com/zed-industries/zed/pull/30768) feature for "extending" doc comments in the same way that Zed can extend line comments on newline. 
2. adds `/*` and `*/` as brackets so that entering `/*` will automatically add `/* */`. This part is copied verbatim from the JS config at https://github.com/zed-industries/zed/blob/main/crates/languages/src/javascript/config.toml#L16, but it also matches the Rust config.

I tested this out by building Zed from `main` and then installing this as a dev extension; it all worked as expected. 

As always, happy to make any changes you'd like to see. Thank you!