### PR TITLE
fix: add overrides for comment (and string)

### DIFF
--- a/languages/php/overrides.scm
+++ b/languages/php/overrides.scm
@@ -1,3 +1,6 @@
 (comment) @comment.inclusive
 
-(string) @string
+[
+  (string)
+  (encapsed_string)
+] @string

--- a/languages/php/overrides.scm
+++ b/languages/php/overrides.scm
@@ -1,0 +1,3 @@
+(comment) @comment.inclusive
+
+(string) @string


### PR DESCRIPTION
Support for extending doc comments on newline has changed since we merged #27, and Zed now requires that languages have a `@comment.inclusive` override for that feature to work. This change adds such an override for PHP comments, and also for `(string)` as well, because that seems to be a common override in other lang extensions.

**Caveat:** I don't understand the relevance of these overrides, and this is very much a "me copy code here. make problem fix gud" sort of fix. 😄  I have read the relevant docs at https://zed.dev/docs/extensions/languages#syntax-overrides but still don't quite see the relevance in this context. But it works. Please correct me if I'm wrong! 😄 

**Repro:** With latest version installed, opening this snippet w/ cursor at `^` and pressing enter will insert a new, blank line, but with this PR, it will insert a line starting with ` * ` as expected.
```php
<?php
/**
 * ^
 */
```


cc @smitbarmase for input/comment on if this config is incorrect