### PR TITLE
chore: Bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "zed_php"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.4.0"
+version = "0.4.1"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-extensions/php"


### PR DESCRIPTION
Contains: c425b50f79d46c6748042a9bec5edfffcc729988

Closes:

- https://github.com/zed-extensions/php/issues/24
- https://github.com/zed-extensions/php/issues/29
- https://github.com/zed-industries/zed/issues/33510