### PR TITLE
Highlight special classes `self` and `parent`

### DIFF
--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -42,9 +42,19 @@
 (nullsafe_member_access_expression
   name: (name) @property)
 
-; Variables
+; Special classes
 
-(relative_scope) @variable.builtin
+(relative_scope) @constructor
+
+((object_creation_expression (name) @constructor)
+ (#any-of? @constructor "self" "parent"))
+
+((binary_expression
+  operator: "instanceof"
+  right: (name) @constructor)
+ (#any-of? @constructor "self" "parent"))
+
+; Variables
 
 ((name) @constant
  (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))


### PR DESCRIPTION
**Motivation (current behavior):**
* `self::` and `parent::` are highlighted as `@variable.builtin`, but no default theme [3] defines a highlighting for `@variable.builtin`, so they end up highlighted as normal variables. This is in stark contrast with `static` (which is highlighted as keyword) - I compare them because `static`, `self` and `parent` are used in similiar way.
* in `new self()`, `self` is not highlighted at all (`copy highlight json` gives `null`)
* in `$x instanceof self`, `self` is not highlighted at all (`copy highlight json` gives `null`)

**Context:**
* `self`, `parent` and `static` are "special classes" [1]
* `static` is also a "keyword" (but `self` and `parent` aren't) [2]
* `relative_scope` refers to `self`, `parent` and `static` [4]
* `static` highlighting is overridden by being a keyword

**Solution:**
* I changed `relative_scope` from `@variable.builtin` to `@contructor`, because they can be used in the same place as a constructor (e.g. `static::Foo()` and `MyClass::Foo()`)
* `relative_scope` doesn't hande `new self()` and `$x instanceof self`, so I added rules for this two cases. Also as `@constructor` (to match `new MyClass()` and `$x instanceof MyClass`)
* Type hints are not affected

**Alternatives:**
* Maybe the themes should be extended to highlight `@variable.builtin`, instead of changing the php extension?
* Maybe they should be highlighted as keyword to match `static`?

**Links:**
* [1] https://www.php.net/manual/en/reserved.classes.php#reserved.classes.special
* [2] https://www.php.net/manual/en/reserved.keywords.php
* [3] https://github.com/zed-industries/zed/tree/main/assets/themes
* [4] https://github.com/tree-sitter/tree-sitter-php/blob/master/common/define-grammar.js#L1200

| Prior to change | With change |
| --- | --- |
 | <img width="771" height="351" alt="Screenshot 2025-08-01 at 22 27 26" src="https://github.com/user-attachments/assets/e6fdc6d0-ecb9-4343-b0a7-18940eaa9c6f" /> | <img width="771" height="351" alt="Screenshot 2025-08-01 at 22 24 11" src="https://github.com/user-attachments/assets/23c1d15c-06ee-4aa9-bd76-4e3c536bbc87" /> |
| <img width="771" height="351" alt="Screenshot 2025-08-01 at 22 27 53" src="https://github.com/user-attachments/assets/cf77d943-6cd9-4ef9-8e4f-bd8514214efd" /> |<img width="771" height="351" alt="Screenshot 2025-08-01 at 22 24 45" src="https://github.com/user-attachments/assets/cd0a93a1-4249-42eb-968e-4d7d79442488" /> | 
 | <img width="771" height="351" alt="Screenshot 2025-08-01 at 22 25 01" src="https://github.com/user-attachments/assets/e636f39a-2f53-41ef-af69-8b57fe833756" /> | <img width="771" height="351" alt="Screenshot 2025-08-01 at 22 28 07" src="https://github.com/user-attachments/assets/9d6a2bde-e634-4585-8646-aa916878798c" /> | 

