### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "zed_php"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_php"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "php"
 name = "PHP"
 description = "PHP support."
-version = "0.4.1"
+version = "0.4.2"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-extensions/php"


### PR DESCRIPTION
This PR bumps the version of the PHP extension to 0.4.2.

Includes:

- https://github.com/zed-extensions/php/pull/40
- https://github.com/zed-extensions/php/pull/48
- https://github.com/zed-extensions/php/pull/49
