### PR TITLE
tasks: Use separate values for arguments

### DIFF
--- a/languages/php/tasks.json
+++ b/languages/php/tasks.json
@@ -2,13 +2,13 @@
   {
     "label": "phpunit test $ZED_SYMBOL",
     "command": "./vendor/bin/phpunit",
-    "args": ["--filter $ZED_SYMBOL $ZED_FILE"],
+    "args": ["--filter", "\"$ZED_SYMBOL\"", "$ZED_FILE"],
     "tags": ["phpunit-test"]
   },
   {
     "label": "pest test $ZED_SYMBOL",
     "command": "./vendor/bin/pest",
-    "args": ["--filter \"$ZED_SYMBOL\" $ZED_FILE"],
+    "args": ["--filter", "\"$ZED_SYMBOL\"", "$ZED_FILE"],
     "tags": ["pest-test"]
   },
   {


### PR DESCRIPTION
I recently started using `pest` and noticed that the test tasks weren't working; this change allows them to work as expected. It also fixes the phpunit task and aligns the quoting between the two tasks.

The current version is trying to execute the tasks like `./vendor/bin/phpunit "--filter $ZED_SYMBOL $ZED_FILE"` when it needs to be `./vendor/bin/phpunit --filter "$ZED_SYMBOL" $ZED_FILE`. (ie there should be 3 separate arguments, not 1 big one)

Out of scope, but heads up: In a followup PR I'd like to push additional tasks to run all tests in the current file, vs only running the "current" test as these tasks currently do.