### PR TITLE
feat(injections): add injections for the comments extension

### DIFF
--- a/languages/php/injections.scm
+++ b/languages/php/injections.scm
@@ -6,6 +6,9 @@
   (#match? @injection.content "^/\\*\\*[^*]")
   (#set! injection.language "phpdoc"))
 
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
 ((heredoc_body) (heredoc_end) @injection.language) @injection.content
 
 ((nowdoc_body) (heredoc_end) @injection.language) @injection.content


### PR DESCRIPTION
This adds an injection for PHP comments to allow the new "comments" extension to work:

![Screenshot 2025-10-08 at 10 16 10 AM](https://github.com/user-attachments/assets/9e33bb82-82f3-4aec-95a3-9473a5d75544)

Ref: https://github.com/thedadams/zed-comment
Ref: https://github.com/zed-industries/zed/commit/e60a61f7e76d1c4c2ddc3bd230cf9c7d78bc0593