### PR TITLE
Update comment configuration

### DIFF
--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -3,7 +3,8 @@ grammar = "php"
 path_suffixes = ["php"]
 first_line_pattern = '^#!.*php'
 line_comments = ["// ", "# "]
-documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
+block_comment = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }
+documentation_comment = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This updates the format of block and doc comments in `config.toml` to the latest format supported by Zed, merged in https://github.com/zed-industries/zed/commit/1f4c9b9427437952839489a6399e5300dd579dfe