### PR TITLE
Add word characters configuration for PHP

### DIFF
--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -18,3 +18,4 @@ scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "php"
 prettier_plugins = ["@prettier/plugin-php"]
 completion_query_characters = ["$"]
+word_characters = ["$"]


### PR DESCRIPTION
Makes it so the $ symbol is also included in the selection when a variable is double-clicked in the editor.