### PR TITLE
debugger: Add basic inline values support

### DIFF
--- a/languages/php/debugger.scm
+++ b/languages/php/debugger.scm
@@ -1,0 +1,28 @@
+; e.g. `$age = 25` matches `$age`
+(expression_statement
+    (assignment_expression
+        left: (variable_name) @debug-variable
+    )
+)
+
+; e.g. `++$age` matches `$age`
+(expression_statement
+    (update_expression
+        argument: (variable_name) @debug-variable
+    )
+)
+
+; e.g. `if ($age > 18)` matches `$age`
+(binary_expression
+    left: (variable_name) @debug-variable
+)
+
+; e.g. `if (18 < $age)` matches `$age`
+(binary_expression
+    right: (variable_name) @debug-variable
+)
+
+; e.g. `__construct(int $age)` matches `$age`
+(simple_parameter
+    name: (variable_name) @debug-variable
+)


### PR DESCRIPTION
This PR adds support for basic inline values for PHP. I think these are the most commonly used inline values.
If we need to add support for more advanced structures, we can do that later.

<img width="740" height="447" alt="Screenshot 2025-12-06 at 17 59 06" src="https://github.com/user-attachments/assets/8e6d8585-37e0-48fc-8c66-4d52657e7284" />