### PR TITLE
Update PHP and PHPDoc grammars

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -24,9 +24,9 @@ language = "PHP"
 
 [grammars.php]
 repository = "https://github.com/tree-sitter/tree-sitter-php"
-commit = "8ab93274065cbaf529ea15c24360cfa3348ec9e4"
+commit = "5b5627faaa290d89eb3d01b9bf47c3bb9e797dea"
 path = "php"
 
 [grammars.phpdoc]
 repository = "https://github.com/claytonrcarter/tree-sitter-phpdoc"
-commit = "03bb10330704b0b371b044e937d5cc7cd40b4999"
+commit = "488198e61f49fc74ee54069a4126b556665a57cc"

--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -1,5 +1,5 @@
 (php_tag) @tag
-"?>" @tag
+(php_end_tag) @tag
 
 ; Types
 
@@ -80,7 +80,7 @@
 ; Basic tokens
 [
   (string)
-  (string_value)
+  (string_content)
   (encapsed_string)
   (heredoc)
   (heredoc_body)
@@ -170,7 +170,6 @@
 "and" @keyword
 "as" @keyword
 "break" @keyword
-"callable" @keyword
 "case" @keyword
 "catch" @keyword
 "class" @keyword
@@ -197,7 +196,6 @@
 "for" @keyword
 "foreach" @keyword
 "fn" @keyword
-"from" @keyword
 "function" @keyword
 "global" @keyword
 "goto" @keyword
@@ -229,3 +227,4 @@
 "while" @keyword
 "xor" @keyword
 "yield" @keyword
+"yield from" @keyword

--- a/languages/php/outline.scm
+++ b/languages/php/outline.scm
@@ -36,8 +36,8 @@
         .
         (argument
             [
-              (encapsed_string (string_value) @name)
-              (string (string_value) @name)
+              (encapsed_string (string_content) @name)
+              (string (string_content) @name)
             ]
         )
     )

--- a/languages/php/runnables.scm
+++ b/languages/php/runnables.scm
@@ -4,8 +4,9 @@
 ; and the method is public
 (
     (class_declaration
-        modifier: (_)? @_modifier
-        (#not-eq? @_modifier "abstract")
+        (_)* @_modifier
+        (#not-any-eq? @_modifier "abstract")
+        .
         name: (_) @_name
         (#match? @_name ".*Test$")
         body: (declaration_list
@@ -26,8 +27,9 @@
 ; and the method is public
 (
     (class_declaration
-        modifier: (_)? @_modifier
-        (#not-eq? @_modifier "abstract")
+        (_)* @_modifier
+        (#not-any-eq? @_modifier "abstract")
+        .
         name: (_) @_name
         (#match? @_name ".*Test$")
         body: (declaration_list
@@ -51,8 +53,9 @@
 ; and the method is public
 (
     (class_declaration
-        modifier: (_)? @_modifier
-        (#not-eq? @_modifier "abstract")
+        (_)* @_modifier
+        (#not-any-eq? @_modifier "abstract")
+        .
         name: (_) @_name
         (#match? @_name ".*Test$")
         body: (declaration_list
@@ -77,8 +80,9 @@
 ; and that doesn't have the abstract modifier
 (
     (class_declaration
-        modifier: (_)? @_modifier
-        (#not-eq? @_modifier "abstract")
+        (_)* @_modifier
+        (#not-any-eq? @_modifier "abstract")
+        .
         name: (_) @run
         (#match? @run ".*Test$")
     ) @_phpunit-test
@@ -95,8 +99,8 @@
             .
             (argument
                 [
-                  (encapsed_string (string_value) @run)
-                  (string (string_value) @run)
+                  (encapsed_string (string_content) @run)
+                  (string (string_content) @run)
                 ]
             )
         )


### PR DESCRIPTION
To v0.24.2 and v0.1.7 respectively. Enables features of PHP 8.4 and 8.5.

- https://github.com/tree-sitter/tree-sitter-php/pull/275
  - `php_end_tag` was added
  - `callable` is no longer a keyword
- https://github.com/tree-sitter/tree-sitter-php/pull/237
  - `string_value` was replaced with `string_content`
  - `modifier` field was removed from `class_declaration`
- Various
  - `yield` and `from` are converted to `yield` and `yield from`