### PR TITLE
Add namespace qualifier highlighting

### DIFF
--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -6,7 +6,8 @@
 (primitive_type) @type.builtin
 (cast_type) @type.builtin
 (named_type (name) @type) @type
-(named_type (qualified_name) @type) @type
+
+(named_type (qualified_name (name) @type))
 
 ; Named arguments (PHP 8+)
 
@@ -71,6 +72,17 @@
 
 ((name) @constructor
  (#match? @constructor "^[A-Z]"))
+
+; Namespace qualifiers
+
+(class_constant_access_expression
+  (qualified_name (namespace_name (name) @label)))
+(scoped_call_expression
+  scope: (qualified_name (namespace_name (name) @label)))
+(object_creation_expression
+  (qualified_name (namespace_name (name) @label)))
+(named_type
+  (qualified_name (namespace_name (name) @label)))
 
 ((name) @variable.builtin
  (#eq? @variable.builtin "this"))


### PR DESCRIPTION
## Summary

Dims namespace qualifiers in inline FQNs using `@label` capture, matching IDE behavior like PhpStorm.

**Before:** `\App\Models\User` - all same color  
**After:** `\App\Models\` - dimmed, `User` - highlighted

## Changes

Targets specific expression contexts where inline FQNs appear:
- Class constant access: `\App\Models\Foo::CONST`
- Static method calls: `\App\Models\Foo::method()`
- Object creation: `new \App\Models\Foo()`
- Type annotations

`use` statements are NOT affected.

## Theme Configuration

```json
"theme_overrides": {
  "One Light": {
    "syntax": {
      "label": { "color": "#a0a1a7" }
    }
  }
}
```

Example:
<img width="652" height="110" alt="image" src="https://github.com/user-attachments/assets/b0cffcf4-4d4a-413f-aa75-a1ce312afc2b" />
