### PR TITLE
Add class properties to symbols outline

### DIFF
--- a/languages/php/outline.scm
+++ b/languages/php/outline.scm
@@ -44,3 +44,9 @@
 ) @item
 
 (comment) @annotation
+
+(property_declaration
+  (property_element
+    name: (variable_name) @name
+  )
+) @item


### PR DESCRIPTION
Currently class properties are not outlined and therefore not showing up in the symbol search in Zed

Test case:
```php
<?php

class TestCase
{
    public $noType;
    protected string $withType = "default";
    private static array $static = [];
    protected readonly bool $readOnly;

    public function __construct(public bool $promotedProperty) {}
}
```

Before this change:
<img width="550" height="125" alt="image" src="https://github.com/user-attachments/assets/434f93e2-3a92-43b7-9dd3-cb9dc6d2546e" />

After this change:
<img width="578" height="250" alt="image" src="https://github.com/user-attachments/assets/4b06ea8d-a25e-4bb8-a058-e03c215af60f" />

Ideally promoted class properties would also work, but this is a start.