### PR TITLE
Fix class constant highlighting

### DIFF
--- a/languages/php/highlights.scm
+++ b/languages/php/highlights.scm
@@ -50,6 +50,11 @@
 (nullsafe_member_access_expression
   name: (name) @property)
 
+; Class constant access (e.g., Class::CONSTANT)
+
+(class_constant_access_expression
+  (_) (name) @constant)
+
 ; Special classes
 
 (relative_scope) @constructor
@@ -64,13 +69,13 @@
 
 ; Variables
 
+((name) @constructor
+ (#match? @constructor "^[A-Z]"))
+
 ((name) @constant
  (#match? @constant "^_?[A-Z][A-Z\\d_]+$"))
 ((name) @constant.builtin
  (#match? @constant.builtin "^__[A-Z][A-Z\d_]+__$"))
-
-((name) @constructor
- (#match? @constructor "^[A-Z]"))
 
 ((name) @variable.builtin
  (#eq? @variable.builtin "this"))


### PR DESCRIPTION
## Summary

- Add explicit `class_constant_access_expression` rule to correctly capture the constant name (e.g., `RESOURCE_RELATIONS` in `Class::CONSTANT`) as `@constant`
- Reorder `@constructor` before `@constant` so UPPER_SNAKE_CASE names get `@constant` instead of being overridden by the generic `@constructor` catch-all

## Problem

Class constants accessed via `::` (e.g., `Conversation::RESOURCE_RELATIONS`) were highlighted as `@constructor` (same as class names) instead of `@constant`. This happened because:

1. The generic `((name) @constructor (#match? @constructor "^[A-Z]"))` pattern matched both `Conversation` and `RESOURCE_RELATIONS`
2. Since it appeared after the `@constant` pattern, it overrode the constant highlighting

## Fix

1. **New rule**: `(class_constant_access_expression (_) (name) @constant)` — explicitly captures the constant name within `::` access expressions. Uses positional matching since this AST node has no named fields.
2. **Reorder**: Move `@constructor` before `@constant` so that for tokens matching both patterns, `@constant` (being last) wins.

## Verified with tree-sitter CLI

```
Conversation     → @constructor ✓
RESOURCE_RELATIONS → @constant ✓
MAX_VALUE        → @constant ✓
PHP_INT_MAX      → @constant ✓
self             → @constructor ✓
```

## Screenshots:

<img width="610" height="93" alt="image" src="https://github.com/user-attachments/assets/2502a452-4609-4b67-831a-ea1cdaf07513" />
<img width="468" height="165" alt="image" src="https://github.com/user-attachments/assets/115dc9a8-c636-4524-b12e-be55d5ccb884" />