### PR TITLE
Recognize `.phpt` files as PHP files

### DIFF
--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -1,6 +1,6 @@
 name = "PHP"
 grammar = "php"
-path_suffixes = ["php", "phtml", "phpt", "stub"]
+path_suffixes = ["php", "phtml", "phpt"]
 first_line_pattern = '^#!.*php'
 line_comments = ["// ", "# "]
 block_comment = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }

--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -1,6 +1,6 @@
 name = "PHP"
 grammar = "php"
-path_suffixes = ["php", "phtml"]
+path_suffixes = ["php", "phtml", "phpt", "stub"]
 first_line_pattern = '^#!.*php'
 line_comments = ["// ", "# "]
 block_comment = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }


### PR DESCRIPTION
Here is a random example of a phpt file: https://github.com/yvoyer/domain-event/blob/3.0.0/examples/blog.phpt

And I decided to add stub as a php file too given that most stub files are php files.

https://github.com/search?q=path%3A*.stub+%22%3C%3Fphp%22&type=code