### PR TITLE
fix: detect PHPUnit #[Test] attribute with fully-qualified name

### DIFF
--- a/languages/php/runnables.scm
+++ b/languages/php/runnables.scm
@@ -49,7 +49,7 @@
 
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
-; and have a method that has the #[Test] attribute
+; and have a method that has the #[Test] attribute (short or fully-qualified form)
 ; and the method is public
 (
     (class_declaration
@@ -62,7 +62,12 @@
             (method_declaration
                 (attribute_list
                     (attribute_group
-                        (attribute (name) @_attribute)
+                        (attribute
+                            [
+                                (name) @_attribute
+                                (qualified_name (name) @_attribute)
+                            ]
+                        )
                     )
                 )
                 (#eq? @_attribute "Test")

--- a/languages/php/runnables.scm
+++ b/languages/php/runnables.scm
@@ -49,7 +49,7 @@
 
 ; Class that follow the naming convention of PHPUnit test classes
 ; and that doesn't have the abstract modifier
-; and have a method that has the #[Test] attribute (short or fully-qualified form)
+; and have a method that has the #[Test] attribute (short imported form)
 ; and the method is public
 (
     (class_declaration
@@ -62,15 +62,41 @@
             (method_declaration
                 (attribute_list
                     (attribute_group
-                        (attribute
-                            [
-                                (name) @_attribute
-                                (qualified_name (name) @_attribute)
-                            ]
-                        )
+                        (attribute (name) @_attribute)
                     )
                 )
                 (#eq? @_attribute "Test")
+                (visibility_modifier)? @_visibility
+                (#eq? @_visibility "public")
+                name: (_) @run
+                (#not-match? @run "^test.*")
+            )
+        )
+    ) @_phpunit-test
+    (#set! tag phpunit-test)
+)
+
+; Class that follow the naming convention of PHPUnit test classes
+; and that doesn't have the abstract modifier
+; and have a method that has the #[Test] attribute (relative- or
+; fully-qualified form), matched against the whole PHPUnit\Framework\Attributes\Test
+; path so it doesn't false-positive on other frameworks' `Test`-named attributes
+; and the method is public
+(
+    (class_declaration
+        (_)* @_modifier
+        (#not-any-eq? @_modifier "abstract")
+        .
+        name: (_) @_name
+        (#match? @_name ".*Test$")
+        body: (declaration_list
+            (method_declaration
+                (attribute_list
+                    (attribute_group
+                        (attribute (qualified_name) @_attribute)
+                    )
+                )
+                (#match? @_attribute "^\\\\?PHPUnit\\\\Framework\\\\Attributes\\\\Test$")
                 (visibility_modifier)? @_visibility
                 (#eq? @_visibility "public")
                 name: (_) @run


### PR DESCRIPTION
## Problem

When a PHPUnit test method is annotated with the fully-qualified attribute form:

```php
#[\PHPUnit\Framework\Attributes\Test]
public function it_does_something(): void { ... }
```

Zed does not show the ▷ gutter play button, so the test cannot be run from the editor. Only the short imported form `#[Test]` triggers the runnable.

## Root cause

The `runnables.scm` query for the `#[Test]` case only matches a simple `name` node inside the `attribute`:

```scm
(attribute (name) @_attribute)
(#eq? @_attribute "Test")
```

For a fully-qualified attribute, the tree-sitter PHP grammar produces a `qualified_name` node instead of a bare `name`. According to the grammar definition, `qualified_name` has the structure:

```
(qualified_name
  prefix: (... \PHPUnit\Framework\Attributes\ ...)
  (name) "Test"   <-- direct child, NOT inside the prefix
)
```

The namespace segments (`PHPUnit`, `Framework`, `Attributes`) are nested inside the `prefix` field, while the class name (`Test`) is a direct `name` child of `qualified_name`. The existing query never reaches this node.

## Fix

Add an alternative branch `(qualified_name (name) @_attribute)` inside the attribute match so both the short and fully-qualified forms are handled:

```scm
(attribute
    [
        (name) @_attribute
        (qualified_name (name) @_attribute)
    ]
)
(#eq? @_attribute "Test")
```

This covers:
- `#[Test]` — short form (existing, unchanged)
- `#[PHPUnit\Framework\Attributes\Test]` — relative qualified form
- `#[\PHPUnit\Framework\Attributes\Test]` — fully-qualified form (global namespace prefix)
