### PR TITLE
Debug test runnables through the Xdebug adapter

### DIFF
--- a/debug_adapter_schemas/Xdebug.json
+++ b/debug_adapter_schemas/Xdebug.json
@@ -20,6 +20,17 @@
       "description": "The PHP script to debug (typically a path to a file)",
       "default": "${file}"
     },
+    "runtimeExecutable": {
+      "type": "string",
+      "description": "Absolute path to the PHP executable the adapter spawns (default: the `php` on your PATH). Set this to a real `php.exe` when `php` on the PATH is a shell shim (a `.bat`/`.cmd` cannot be launched directly)."
+    },
+    "runtimeArgs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Arguments passed to the PHP executable before the program (for example `-dxdebug.mode=debug`)"
+    },
     "cwd": {
       "type": "string",
       "description": "Working directory for the debugged program"

--- a/debug_adapter_schemas/Xdebug.json
+++ b/debug_adapter_schemas/Xdebug.json
@@ -176,5 +176,5 @@
       }
     }
   },
-  "required": ["request", "program"]
+  "required": ["request"]
 }

--- a/extension.toml
+++ b/extension.toml
@@ -27,6 +27,8 @@ language_ids = { PHP = "php" }
 
 [debug_adapters.Xdebug]
 
+[debug_locators.php]
+
 [grammars.php]
 repository = "https://github.com/tree-sitter/tree-sitter-php"
 commit = "5b5627faaa290d89eb3d01b9bf47c3bb9e797dea"

--- a/languages/php/config.toml
+++ b/languages/php/config.toml
@@ -20,3 +20,4 @@ prettier_parser_name = "php"
 prettier_plugins = ["@prettier/plugin-php"]
 completion_query_characters = ["$"]
 word_characters = ["$"]
+debuggers = ["Xdebug"]

--- a/src/php.rs
+++ b/src/php.rs
@@ -5,7 +5,7 @@ use std::fs;
 use zed::CodeLabel;
 use zed_extension_api::{
     self as zed, DebugConfig, DebugScenario, LanguageServerId, Result,
-    StartDebuggingRequestArgumentsRequest, serde_json,
+    StartDebuggingRequestArgumentsRequest, TaskTemplate, serde_json,
 };
 
 use crate::{
@@ -165,6 +165,16 @@ impl zed::Extension for PhpExtension {
         }
         self.xdebug
             .get_binary(config, user_provided_debug_adapter_path, worktree)
+    }
+    fn dap_locator_create_scenario(
+        &mut self,
+        _locator_name: String,
+        build_task: TaskTemplate,
+        resolved_label: String,
+        debug_adapter_name: String,
+    ) -> Option<DebugScenario> {
+        self.xdebug
+            .dap_locator_create_scenario(build_task, resolved_label, debug_adapter_name)
     }
 }
 

--- a/src/xdebug.rs
+++ b/src/xdebug.rs
@@ -210,41 +210,53 @@ impl XDebug {
             if obj.get("cwd").is_none_or(Value::is_null) {
                 obj.insert("cwd".to_string(), worktree.root_path().into());
             }
-            // The adapter spawns PHP itself; on Windows `spawn("php")` won't find
-            // `php.exe` on the PATH, so hand it the absolute path we resolve here
-            // (honoring a `PHP_BINARY` override for shell-shim setups).
-            if !obj.contains_key("runtimeExecutable") {
-                if let Some(php) = resolve_php_runtime(worktree) {
+            // A launch config with a `program` runs a PHP script (CLI debugging);
+            // one without just listens for incoming Xdebug connections (web
+            // debugging). Only the former spawns PHP, so the PHP binary and the
+            // Xdebug-enabling args belong there only — injecting them into a
+            // listener would make the adapter try to spawn `php` with no script
+            // instead of listening.
+            let launches_program = obj
+                .get("program")
+                .and_then(Value::as_str)
+                .is_some_and(|program| !program.is_empty());
+            if launches_program {
+                // The adapter spawns PHP itself; on Windows `spawn("php")` won't find
+                // `php.exe` on the PATH, so hand it the absolute path we resolve here
+                // (honoring a `PHP_BINARY` override for shell-shim setups).
+                if !obj.contains_key("runtimeExecutable")
+                    && let Some(php) = resolve_php_runtime(worktree)
+                {
                     obj.insert("runtimeExecutable".to_string(), php.into());
                 }
-            }
-            // The adapter forwards `runtimeArgs` to PHP verbatim; it does NOT enable
-            // Xdebug on its own. Without these `-dxdebug…` overrides the launched
-            // script never connects back and breakpoints never bind. `${port}` is
-            // replaced by the adapter with the DBGp port it listens on, so it always
-            // matches. Users can override by setting their own `runtimeArgs`.
-            // (Xdebug must still be loaded in PHP via `zend_extension`.)
-            if !obj.contains_key("runtimeArgs") {
-                obj.insert(
-                    "runtimeArgs".to_string(),
-                    json!([
-                        "-dxdebug.mode=debug",
-                        "-dxdebug.start_with_request=yes",
-                        "-dxdebug.client_port=${port}"
-                    ]),
-                );
-            }
-            // The debug adapter spawns PHP directly (no shell), and Node refuses to
-            // launch `.bat`/`.cmd` files (CVE-2024-27980), failing with a cryptic
-            // `spawn EINVAL`. Turn that into an actionable message.
-            if let Some(runtime) = obj.get("runtimeExecutable").and_then(Value::as_str) {
-                let ext = runtime.to_ascii_lowercase();
-                if ext.ends_with(".bat") || ext.ends_with(".cmd") {
-                    return Err(format!(
-                        "Cannot debug through the shell shim `{runtime}`: the debug adapter \
-                         spawns PHP directly and Windows batch files can't be launched that way. \
-                         Point `PHP_BINARY` (or a `runtimeExecutable` in your debug config) at a real `php.exe`."
-                    ));
+                // The adapter forwards `runtimeArgs` to PHP verbatim; it does NOT
+                // enable Xdebug on its own. Without these `-dxdebug…` overrides the
+                // launched script never connects back and breakpoints never bind.
+                // `${port}` is replaced by the adapter with the DBGp port it listens
+                // on, so it always matches. Users can override with their own
+                // `runtimeArgs`. (Xdebug must still be loaded via `zend_extension`.)
+                if !obj.contains_key("runtimeArgs") {
+                    obj.insert(
+                        "runtimeArgs".to_string(),
+                        json!([
+                            "-dxdebug.mode=debug",
+                            "-dxdebug.start_with_request=yes",
+                            "-dxdebug.client_port=${port}"
+                        ]),
+                    );
+                }
+                // The debug adapter spawns PHP directly (no shell), and Node refuses
+                // to launch `.bat`/`.cmd` files (CVE-2024-27980), failing with a
+                // cryptic `spawn EINVAL`. Turn that into an actionable message.
+                if let Some(runtime) = obj.get("runtimeExecutable").and_then(Value::as_str) {
+                    let ext = runtime.to_ascii_lowercase();
+                    if ext.ends_with(".bat") || ext.ends_with(".cmd") {
+                        return Err(format!(
+                            "Cannot debug through the shell shim `{runtime}`: the debug adapter \
+                             spawns PHP directly and Windows batch files can't be launched that way. \
+                             Point `PHP_BINARY` (or a `runtimeExecutable` in your debug config) at a real `php.exe`."
+                        ));
+                    }
                 }
             }
         }

--- a/src/xdebug.rs
+++ b/src/xdebug.rs
@@ -3,13 +3,35 @@ use std::{env, path::Path, str::FromStr, sync::OnceLock};
 use zed_extension_api::{
     DebugAdapterBinary, DebugConfig, DebugRequest, DebugScenario, DownloadedFileType,
     GithubReleaseAsset, GithubReleaseOptions, StartDebuggingRequestArguments,
-    StartDebuggingRequestArgumentsRequest, TcpArguments, TcpArgumentsTemplate, download_file,
-    latest_github_release, node_binary_path, resolve_tcp_template,
+    StartDebuggingRequestArgumentsRequest, TaskTemplate, TcpArguments, TcpArgumentsTemplate,
+    download_file, latest_github_release, node_binary_path, resolve_tcp_template,
     serde_json::{self, Value, json},
 };
 
 pub(super) struct XDebug {
     current_version: OnceLock<String>,
+}
+
+/// Drop the double quotes that `tasks.json` adds for the "Run" shell. PHP
+/// identifiers and file paths never contain `"`, so removing every quote is
+/// safe and leaves a clean argv element for the debug adapter to spawn.
+fn strip_shell_quotes(arg: &str) -> String {
+    arg.replace('"', "")
+}
+
+/// The PHP binary the adapter should spawn, when the scenario doesn't already
+/// pin a `runtimeExecutable`. Prefer the `PHP_BINARY` environment variable so a
+/// project can point at a real `php.exe` when `php` on the PATH is a shell shim
+/// (a `.bat`/`.cmd` the debug adapter can't spawn directly); otherwise fall back
+/// to whatever `php` resolves to on the PATH.
+fn resolve_php_runtime(worktree: &zed_extension_api::Worktree) -> Option<String> {
+    worktree
+        .shell_env()
+        .into_iter()
+        .find(|(key, _)| key == "PHP_BINARY")
+        .map(|(_, value)| value)
+        .filter(|value| !value.is_empty())
+        .or_else(|| worktree.which("php"))
 }
 
 impl XDebug {
@@ -65,6 +87,65 @@ impl XDebug {
             tcp_connection: None,
         })
     }
+    /// Turn a runnable task (a PHPUnit/Pest/Testo command from `tasks.json`) into
+    /// an Xdebug launch scenario, so the gutter offers a "Debug" counterpart to
+    /// its "Run". Zed runs this against every task; we only claim the ones that
+    /// boil down to launching a PHP entrypoint.
+    pub(crate) fn dap_locator_create_scenario(
+        &self,
+        build_task: TaskTemplate,
+        resolved_label: String,
+        adapter: String,
+    ) -> Option<DebugScenario> {
+        if adapter != Self::NAME {
+            return None;
+        }
+
+        // `php vendor/bin/testo …` launches the script in the first argument;
+        // `./vendor/bin/phpunit …` is itself the PHP entrypoint. Skip inline code
+        // like `php -r <code>`, which has no program to debug.
+        let (program, args) = match build_task.command.as_str() {
+            "php" => {
+                let program = build_task.args.first()?;
+                if program.starts_with('-') {
+                    return None;
+                }
+                (program.clone(), build_task.args[1..].to_vec())
+            }
+            command => (command.to_string(), build_task.args.clone()),
+        };
+        // `tasks.json` quotes values for the shell that runs "Run"
+        // (e.g. `--path="$ZED_RELATIVE_FILE"`). The debug adapter spawns the
+        // process directly (argv, no shell), so those quotes must come off.
+        let program = strip_shell_quotes(&program);
+        let args: Vec<String> = args.iter().map(|a| strip_shell_quotes(a)).collect();
+
+        let env = Value::Object(
+            build_task
+                .env
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        );
+
+        let config = json!({
+            "request": "launch",
+            "program": program,
+            "args": args,
+            "cwd": build_task.cwd,
+            "env": env,
+            "stopOnEntry": false,
+        });
+
+        Some(DebugScenario {
+            adapter,
+            label: resolved_label,
+            build: None,
+            config: config.to_string(),
+            tcp_connection: None,
+        })
+    }
+
     fn fetch_latest_adapter_version() -> Result<(GithubReleaseAsset, String), String> {
         let release = latest_github_release(
             "xdebug/vscode-php-debug",
@@ -123,8 +204,49 @@ impl XDebug {
         let mut configuration = Value::from_str(&task_definition.config)
             .map_err(|e| format!("Invalid JSON configuration: {e}"))?;
         if let Some(obj) = configuration.as_object_mut() {
-            obj.entry("cwd")
-                .or_insert_with(|| worktree.root_path().into());
+            // Tasks carry no `cwd`, so a locator-built scenario has `"cwd": null`;
+            // fill it with the worktree root. `entry(..).or_insert` wouldn't fire
+            // here — the key is present, just null.
+            if obj.get("cwd").is_none_or(Value::is_null) {
+                obj.insert("cwd".to_string(), worktree.root_path().into());
+            }
+            // The adapter spawns PHP itself; on Windows `spawn("php")` won't find
+            // `php.exe` on the PATH, so hand it the absolute path we resolve here
+            // (honoring a `PHP_BINARY` override for shell-shim setups).
+            if !obj.contains_key("runtimeExecutable") {
+                if let Some(php) = resolve_php_runtime(worktree) {
+                    obj.insert("runtimeExecutable".to_string(), php.into());
+                }
+            }
+            // The adapter forwards `runtimeArgs` to PHP verbatim; it does NOT enable
+            // Xdebug on its own. Without these `-dxdebug…` overrides the launched
+            // script never connects back and breakpoints never bind. `${port}` is
+            // replaced by the adapter with the DBGp port it listens on, so it always
+            // matches. Users can override by setting their own `runtimeArgs`.
+            // (Xdebug must still be loaded in PHP via `zend_extension`.)
+            if !obj.contains_key("runtimeArgs") {
+                obj.insert(
+                    "runtimeArgs".to_string(),
+                    json!([
+                        "-dxdebug.mode=debug",
+                        "-dxdebug.start_with_request=yes",
+                        "-dxdebug.client_port=${port}"
+                    ]),
+                );
+            }
+            // The debug adapter spawns PHP directly (no shell), and Node refuses to
+            // launch `.bat`/`.cmd` files (CVE-2024-27980), failing with a cryptic
+            // `spawn EINVAL`. Turn that into an actionable message.
+            if let Some(runtime) = obj.get("runtimeExecutable").and_then(Value::as_str) {
+                let ext = runtime.to_ascii_lowercase();
+                if ext.ends_with(".bat") || ext.ends_with(".cmd") {
+                    return Err(format!(
+                        "Cannot debug through the shell shim `{runtime}`: the debug adapter \
+                         spawns PHP directly and Windows batch files can't be launched that way. \
+                         Point `PHP_BINARY` (or a `runtimeExecutable` in your debug config) at a real `php.exe`."
+                    ));
+                }
+            }
         }
 
         Ok(DebugAdapterBinary {
@@ -189,5 +311,98 @@ impl XDebug {
             }
         }
         self.get_installed_binary(config, user_provided_debug_adapter_path, worktree)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(command: &str, args: &[&str]) -> TaskTemplate {
+        TaskTemplate {
+            label: "run".into(),
+            command: command.into(),
+            args: args.iter().map(|a| (*a).into()).collect(),
+            env: vec![],
+            cwd: None,
+        }
+    }
+
+    fn scenario_config(build_task: TaskTemplate) -> Value {
+        let scenario = XDebug::new()
+            .dap_locator_create_scenario(build_task, "label".into(), XDebug::NAME.into())
+            .expect("locator claims the task");
+        assert_eq!(scenario.adapter, XDebug::NAME);
+        Value::from_str(&scenario.config).expect("scenario config is JSON")
+    }
+
+    #[test]
+    fn testo_command_launches_the_script_after_php() {
+        // `php vendor/bin/testo …` → program is the script, php drops out.
+        let config = scenario_config(task(
+            "php",
+            &["vendor/bin/testo", "--path=tests/Foo.php", "--filter=bar"],
+        ));
+        assert_eq!(config["request"], "launch");
+        assert_eq!(config["program"], "vendor/bin/testo");
+        assert_eq!(
+            config["args"],
+            json!(["--path=tests/Foo.php", "--filter=bar"])
+        );
+    }
+
+    #[test]
+    fn phpunit_binary_is_itself_the_program() {
+        // `./vendor/bin/phpunit …` is already a PHP entrypoint; args pass through.
+        let config = scenario_config(task(
+            "./vendor/bin/phpunit",
+            &["--filter", "bar", "tests/Foo.php"],
+        ));
+        assert_eq!(config["program"], "./vendor/bin/phpunit");
+        assert_eq!(config["args"], json!(["--filter", "bar", "tests/Foo.php"]));
+    }
+
+    #[test]
+    fn shell_quotes_are_stripped_from_argv() {
+        // `tasks.json` wraps values for the shell; argv must be quote-free.
+        let config = scenario_config(task(
+            "php",
+            &[
+                "vendor/bin/testo",
+                "--path=\"tests/Foo.php\"",
+                "--filter=\"bar\"",
+            ],
+        ));
+        assert_eq!(
+            config["args"],
+            json!(["--path=tests/Foo.php", "--filter=bar"])
+        );
+    }
+
+    #[test]
+    fn inline_php_code_is_not_debuggable() {
+        // `php -r <code>` has no program to break in.
+        assert!(
+            XDebug::new()
+                .dap_locator_create_scenario(
+                    task("php", &["-r", "echo 1;"]),
+                    "label".into(),
+                    XDebug::NAME.into(),
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn other_adapters_are_declined() {
+        assert!(
+            XDebug::new()
+                .dap_locator_create_scenario(
+                    task("php", &["vendor/bin/testo"]),
+                    "label".into(),
+                    "SomethingElse".into(),
+                )
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## What

Lets you debug PHP test runnables with the bundled Xdebug adapter: the gutter now offers **Debug** next to **Run** for the PHPUnit/Pest runnables (and any `php <script>` task), launching the exact test under the cursor with breakpoints. It also enables Xdebug's listen mode for debugging incoming web requests.

The extension already ships the Xdebug debug adapter, but nothing connected it to the runnable tasks, and the PHP language wasn't associated with any debugger — so no debug affordance ever appeared. This PR wires that up.

<img width="823" height="261" alt="image" src="https://github.com/user-attachments/assets/c1102362-c3f8-4113-9924-bd243645ba76" />
<img width="1077" height="679" alt="image" src="https://github.com/user-attachments/assets/06a2b40d-0266-47aa-9612-aed9d45f5d46" />


## How

- **Language ↔ adapter.** `languages/php/config.toml` gains `debuggers = ["Xdebug"]`. Without this, `code_actions.rs::debug_scenarios` bails out early (no default debug adapter for the buffer) and never reaches a locator.
- **Debug locator.** A new `[debug_locators.php]` and `dap_locator_create_scenario` turn a runnable task into an Xdebug launch scenario. It drops the `php` wrapper to find the program, strips the double quotes `tasks.json` adds for the "Run" shell (the adapter spawns argv directly, without a shell), and skips inline `php -r` code.
- **Launch-config fixups at spawn time** (`get_installed_binary`, the single choke point every scenario passes through — gutter, `debug.json`, F4). These apply only when the config has a `program` (a CLI launch); see listen mode below:
  - `cwd` → worktree root (a locator scenario carries `"cwd": null`, which `entry(..).or_insert` wouldn't fill);
  - `runtimeExecutable` → absolute php, via a `PHP_BINARY` env override then `which("php")`, because `spawn("php")` can't resolve a bare name on Windows;
  - `runtimeArgs` → `-dxdebug.mode=debug -dxdebug.start_with_request=yes -dxdebug.client_port=${port}`. The adapter forwards `runtimeArgs` to PHP verbatim and never enables Xdebug itself, so without these the launched script never connects back. `${port}` is replaced by the adapter with the DBGp port it listens on, so it always matches. A user's own `runtimeArgs` take precedence.
  - When php resolves to a `.bat`/`.cmd` shim, fail with an actionable message instead of the cryptic `spawn EINVAL` Node throws for batch files (CVE-2024-27980).
- **Schema.** `debug_adapter_schemas/Xdebug.json` documents `runtimeExecutable` and `runtimeArgs`, so they autocomplete when editing `.zed/debug.json`.

## Listen mode (debugging web requests)

The same adapter listens for incoming Xdebug connections when a launch config has **no** `program` — the usual workflow for debugging a request triggered from the browser or an external CLI run. Because the spawn-time fixups above are gated on `program`, a program-less config is left untouched: the adapter listens instead of trying to spawn `php` with no script, and the `.bat`/`.cmd` guard doesn't reject a session that never launches PHP.

Set it up:

1. Add a program-less scenario to `.zed/debug.json`:

   ```json
   [{ "adapter": "Xdebug", "label": "Listen for Xdebug", "request": "launch" }]
   ```

2. Open `debugger: start`, pick **Listen for Xdebug** from the list and start it. The session now listens on the DBGp port (9003 by default; set `"port"` in the config to change it) — no executable to fill in.
3. Set your breakpoints.
4. Run PHP with Xdebug pointed at the listener, e.g.:

   ```
   php -dxdebug.mode=debug -dxdebug.start_with_request=yes \
       -dxdebug.client_host=127.0.0.1 -dxdebug.client_port=9003 \
       vendor/bin/phpunit
   ```

   or configure the same via `php.ini` / `XDEBUG_MODE=debug` and just trigger a web request. Xdebug connects back to the listening session and breakpoints bind.

## Requirements

Breakpoints require Xdebug to be loaded in the PHP that runs (via `zend_extension`); the `-dxdebug.*` overrides only configure an already-installed Xdebug, they don't load it.

## Tests

Unit tests in `src/xdebug.rs` cover the locator: the testo/phpunit program split, quote stripping, declining inline code, and declining other adapters. `cargo test`, `cargo fmt --check` and `cargo clippy --all-features -- -D warnings` (wasm target) are green.

