### PR TITLE
Inject regex and printf format strings into PHP strings

### DIFF
--- a/languages/php/injections.scm
+++ b/languages/php/injections.scm
@@ -9,8 +9,61 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
 
+; Inject the heredoc/nowdoc body as the language named by its tag. Zed resolves
+; the tag against language names and file extensions, case-insensitively, so
+; `<<<SQL`, `<<<HTML`, `<<<JSON`, `<<<JS`, `<<<YML`, `<<<MD`, ... all work.
 ((heredoc_body)
   (heredoc_end) @injection.language) @injection.content
 
 ((nowdoc_body)
   (heredoc_end) @injection.language) @injection.content
+
+; Highlight the pattern argument of the PCRE functions as a regular expression.
+; Only functions whose first argument is a pattern (not `preg_quote`, whose
+; first argument is a literal string to escape).
+(function_call_expression
+  function: (name) @_preg
+  arguments: (arguments
+    .
+    (argument
+      [
+        (string
+          (string_content) @injection.content)
+        (encapsed_string
+          (string_content) @injection.content)
+      ]))
+  (#any-of? @_preg
+    "preg_match" "preg_match_all" "preg_replace" "preg_replace_callback" "preg_split" "preg_grep")
+  (#set! injection.language "regex"))
+
+; Highlight printf-style format strings (format is the first argument).
+(function_call_expression
+  function: (name) @_fmt
+  arguments: (arguments
+    .
+    (argument
+      [
+        (string
+          (string_content) @injection.content)
+        (encapsed_string
+          (string_content) @injection.content)
+      ]))
+  (#any-of? @_fmt "sprintf" "printf" "vsprintf" "vprintf")
+  (#set! injection.language "printf"))
+
+; ... and where the format is the second argument.
+(function_call_expression
+  function: (name) @_fmt
+  arguments: (arguments
+    .
+    (argument)
+    .
+    (argument
+      [
+        (string
+          (string_content) @injection.content)
+        (encapsed_string
+          (string_content) @injection.content)
+      ]))
+  (#any-of? @_fmt "fprintf" "vfprintf" "sscanf" "fscanf")
+  (#set! injection.language "printf"))


### PR DESCRIPTION
## What

Highlight embedded mini-languages inside PHP string arguments via tree-sitter injections.

- **Regular expressions** — the pattern argument of the PCRE functions (`preg_match`, `preg_match_all`, `preg_replace`, `preg_replace_callback`, `preg_split`, `preg_grep`) is injected as `regex`, so character classes, groups, quantifiers and anchors are highlighted. `preg_quote` is intentionally excluded — its first argument is a literal string to escape, not a pattern.
- **printf-style format strings** — the format argument of `printf`/`sprintf`/`vprintf`/`vsprintf` (first argument) and `fprintf`/`vfprintf`/`sscanf`/`fscanf` (second argument) is injected as `printf`. Zed doesn't currently bundle a `printf` grammar, so this is dormant today (a harmless no-op, same as the java extension's `printf` injection) and lights up automatically if a compatible grammar is registered.

Heredoc/nowdoc bodies are untouched: Zed already resolves the tag against language names and file extensions case-insensitively (`language_for_name_or_extension`), so `<<<SQL`, `<<<HTML`, `<<<JSON`, `<<<JS`, `<<<YML`, ... already inject without per-language rules.

<img width="477" height="506" alt="image" src="https://github.com/user-attachments/assets/622529b8-1335-498b-897c-9e76fb932922" />

## Notes

`regex` is bundled with Zed, so it highlights out of the box. Injection highlights the source text and does not apply PHP's string-escape unescaping, so a pattern is best written in a single-quoted string with single backslashes (`'/\w+/'`); a doubled backslash (`'/\\w+/'`) is read by the regex grammar as an escaped backslash, which is correct for the source but not PHP's runtime value.
