### PR TITLE
Enable caching of `/vendor/` folder by default for phptools

### DIFF
--- a/src/language_servers/phptools.rs
+++ b/src/language_servers/phptools.rs
@@ -36,7 +36,7 @@ impl PhpTools {
             command: server_path,
             args: vec![
                 "--composerNodes".into(),
-                "false".into(), // disable /vendor/ caching
+                "true".into(), // enable /vendor/ caching
             ],
             env: Default::default(),
         })


### PR DESCRIPTION
This change enables caching of /vendor/ folder, this enables fast startup and low memory usage once the vendor is cached.

The default Laravel 13.x project should load in ~2 seconds, consuming ~200MB RAM.