### PR TITLE
Add indentation rule for array creation expressions

### DIFF
--- a/languages/php/indents.scm
+++ b/languages/php/indents.scm
@@ -1,3 +1,5 @@
 (_
   "{"
   "}" @end) @indent
+
+(array_creation_expression "]" @end) @indent

--- a/languages/php/indents.scm
+++ b/languages/php/indents.scm
@@ -2,5 +2,8 @@
   "{"
   "}" @end) @indent
 
-(array_creation_expression "]" @end) @indent
-(array_creation_expression ")" @end) @indent
+(array_creation_expression
+  "]" @end) @indent
+
+(array_creation_expression
+  ")" @end) @indent

--- a/languages/php/indents.scm
+++ b/languages/php/indents.scm
@@ -3,3 +3,4 @@
   "}" @end) @indent
 
 (array_creation_expression "]" @end) @indent
+(array_creation_expression ")" @end) @indent


### PR DESCRIPTION
Adds indentation rules for PHP array creation expressions.

Pressing Enter after an opening `[` or `array(` left the new line at column 0. `indents.scm` only matched nodes containing `{`/`}`, so neither array form was covered - both use brackets or parentheses.

Before:
```php
$foo->bar([
line at column 0
]);
```

After:
```php
$foo->bar([
    line indented one level
]);
```

Both short `[]` and legacy `array()` syntax are handled; in tree-sitter-php both produce an array_creation_expression` node, differing only in the closing delimiter.

Note the rules are scoped to `array_creation_expression` rather than matching `]` or `)` generally, since `]` also closes array access (`$foo['bar']`).

Tested locally on Zed v1.13.1 with a fresh profile.

Fixes #138