### PR TITLE
Add php-lsp language server

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -25,6 +25,11 @@ name = "PHPantom"
 language = "PHP"
 language_ids = { PHP = "php" }
 
+[language_servers.php-lsp]
+name = "php-lsp"
+language = "PHP"
+language_ids = { PHP = "php" }
+
 [debug_adapters.Xdebug]
 
 [grammars.php]

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,9 +1,11 @@
 mod intelephense;
+mod php_lsp;
 mod phpactor;
 mod phpantom;
 mod phptools;
 
 pub use intelephense::*;
+pub use php_lsp::*;
 pub use phpactor::*;
 pub use phpantom::*;
 pub use phptools::*;

--- a/src/language_servers/php_lsp.rs
+++ b/src/language_servers/php_lsp.rs
@@ -1,0 +1,140 @@
+use std::fs;
+
+use zed_extension_api::settings::LspSettings;
+use zed_extension_api::{self as zed, DownloadedFileType, LanguageServerId, Result};
+
+const REPO: &str = "jorgsowa/php-lsp";
+const BINARY_NAME: &str = "php-lsp";
+
+pub struct PhpLsp {
+    cached_binary_path: Option<String>,
+}
+
+impl PhpLsp {
+    pub const LANGUAGE_SERVER_ID: &'static str = "php-lsp";
+
+    pub fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    pub fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        // Allow users to point at their own build via
+        // `lsp.php-lsp.binary.{path,arguments}` in the settings.
+        if let Some(binary) = LspSettings::for_worktree("php-lsp", worktree)
+            .ok()
+            .and_then(|settings| settings.binary)
+            && let Some(path) = binary.path
+        {
+            return Ok(zed::Command {
+                command: path,
+                args: binary.arguments.unwrap_or_default(),
+                env: Default::default(),
+            });
+        }
+
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec![],
+            env: Default::default(),
+        })
+    }
+
+    fn language_server_binary_path(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<String> {
+        if let Some(path) = worktree.which(BINARY_NAME) {
+            return Ok(path);
+        }
+
+        if let Some(path) = &self.cached_binary_path
+            && fs::metadata(path).is_ok_and(|stat| stat.is_file())
+        {
+            return Ok(path.clone());
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            REPO,
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (platform, arch) = zed::current_platform();
+
+        let (os_str, file_type) = match platform {
+            zed::Os::Mac => ("apple-darwin", DownloadedFileType::GzipTar),
+            zed::Os::Linux => ("unknown-linux-gnu", DownloadedFileType::GzipTar),
+            zed::Os::Windows => ("pc-windows-msvc", DownloadedFileType::Zip),
+        };
+
+        let arch_str = match arch {
+            zed::Architecture::Aarch64 => "aarch64",
+            zed::Architecture::X8664 => "x86_64",
+            _ => return Err(format!("unsupported architecture: {arch:?}")),
+        };
+
+        let asset_name = format!(
+            "{BINARY_NAME}-{arch_str}-{os_str}.{extension}",
+            extension = match file_type {
+                DownloadedFileType::GzipTar => "tar.gz",
+                DownloadedFileType::Zip => "zip",
+                _ => "",
+            }
+        );
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| {
+                format!(
+                    "no release asset found matching {asset_name:?} — you may need to build \
+                     {BINARY_NAME} from source for your platform"
+                )
+            })?;
+
+        let version_dir = format!("{BINARY_NAME}-{}", release.version);
+        fs::create_dir_all(&version_dir).map_err(|e| format!("failed to create directory: {e}"))?;
+
+        let binary_path = match platform {
+            zed::Os::Windows => format!("{version_dir}/{BINARY_NAME}.exe"),
+            _ => format!("{version_dir}/{BINARY_NAME}"),
+        };
+
+        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(&asset.download_url, &version_dir, file_type)
+                .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
+
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory: {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry: {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(binary_path)
+    }
+}

--- a/src/php.rs
+++ b/src/php.rs
@@ -9,7 +9,7 @@ use zed_extension_api::{
 };
 
 use crate::{
-    language_servers::{Intelephense, PhpTools, Phpactor, Phpantom},
+    language_servers::{Intelephense, PhpLsp, PhpTools, Phpactor, Phpantom},
     xdebug::XDebug,
 };
 
@@ -18,6 +18,7 @@ struct PhpExtension {
     intelephense: Option<Intelephense>,
     phpactor: Option<Phpactor>,
     phpantom: Option<Phpantom>,
+    php_lsp: Option<PhpLsp>,
     xdebug: XDebug,
 }
 
@@ -28,6 +29,7 @@ impl zed::Extension for PhpExtension {
             intelephense: None,
             phpactor: None,
             phpantom: None,
+            php_lsp: None,
             xdebug: XDebug::new(),
         }
     }
@@ -90,6 +92,10 @@ impl zed::Extension for PhpExtension {
             Phpantom::LANGUAGE_SERVER_ID => {
                 let phpantom = self.phpantom.get_or_insert_with(Phpantom::new);
                 phpantom.language_server_command(language_server_id, worktree)
+            }
+            PhpLsp::LANGUAGE_SERVER_ID => {
+                let php_lsp = self.php_lsp.get_or_insert_with(PhpLsp::new);
+                php_lsp.language_server_command(language_server_id, worktree)
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }


### PR DESCRIPTION
Adds [jorgsowa/php-lsp](https://github.com/jorgsowa/php-lsp) as a fifth selectable language server alongside PhpTools, Intelephense, Phpactor, and PHPantom.

## Why php-lsp

- **Full workspace scan** — cross-file diagnostics and navigation across the whole project, not just the open buffer
- **Fastest LSP available** — Rust-native, async-first with tokio, lock-free document store, no GC pauses
- **Full LSP 3.17 specification support** — call hierarchy, type hierarchy, semantic tokens, inlay hints, selection range, linked editing, and more
- **Rich code actions** — extract variable/method/constant, inline variable, generate constructor/getters/setters, implement missing methods, organize imports, add PHPDoc, add return type
- **Rich diagnostics** — built-in analyzer works out of the box with zero configuration; a project's own PHPStan/PHPCS setup layers on top as an opt-in overlay rather than a replacement
- **Laravel-aware** — route/view/translation/env/asset completion and navigation, Blade template support, facade-to-DI conversion, and more